### PR TITLE
Idea — Use runtime-provided Socket API, if available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ export function connect(
   address: SocketAddress | string,
   options?: SocketOptions,
 ): Socket {
+  if (navigator.userAgent === 'Cloudflare-Workers') {
+    const { connect } = await import("cloudflare:sockets");
+    return connect(address, options);
+  }
   if (typeof address === 'string') {
     const url = new URL(address);
     // eslint-disable-next-line no-param-reassign -- there is no harm reassigning to this param


### PR DESCRIPTION
A thought — would this have the highest impact if implemented as a polyfill?

Right now, this implementation assumes a Node.js environment, and wraps `node:net` and `node:tls`. It is effectively "an implementation of the `connect()` API that works in Node.js".

Library maintainers who need their library to work across runtimes would benefit most from a polyfill, where, if `connect()` is available, it is used directly, and runtime-specific APIs are never imported. That way, maintainers could just pull in this polyfill, and trust that it'd work across *both* Node.js and other runtimes that already provide the sockets API natively.

I can clean this up, and handle moving the Node.js imports to be conditional (to ensure that this can run in non-Node.js environments) —  but I first wanted to submit the idea to get on the same page. Could also extend this to have logic that covered checking if you're in a Vercel Edge Functions environment, or any other runtime that makes the sockets available directly.

Thoughts? cc @jasnell — thinking back to the `fetch()` API — being able to pull in a polyfill that'd work across environments seemed at the time to me like it really helped libraries start adopting it, even as it took time to become available everywhere. But maybe there are dragons and downsides I'm not seeing of taking this approach :)