### PR TITLE
Remove "tcp://" from address in SocketError test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -140,7 +140,7 @@ void tap.test('SocketError is thrown on connect failure', async (t) => {
   t.plan(1);
 
   try {
-    const socket = connect('tcp://127.0.0.1:1234');
+    const socket = connect('127.0.0.1:1234');
     await socket.closed;
   } catch (err) {
     t.same(err, new SocketError('connect ECONNREFUSED 127.0.0.1:1234'));


### PR DESCRIPTION
This PR addresses the failing test `'SocketError is thrown on connect failure'` because of `tcp://` prefix at the start of socket address string. Removing this prefix allowed the test to pass successfully. 

<img width="621" alt="image" src="https://github.com/Ethan-Arrowood/socket/assets/51193034/70caa98f-b0c7-44c8-93b1-53a5820e7db9">

However, if this is not desired, ignore (and close) the PR and fix the issue other way. 😄  
