### PR TITLE
Update readme to link to proposal, link to pg-cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # @arrowood.dev/socket
 
-A Node.js Implementation of the Cloudflare Socket API
+A Node.js Implementation of `connect()`, the [TCP Socket API](https://github.com/wintercg/proposal-sockets-api) proposed within WinterCG, and implemented in [Cloudflare Workers](https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/).
+
+You can use this to provide the `connect()` API in a Node.js environment.
+
+If you need to provide an interface similar to `net.connect()` or `tls.connect()` from Node.js, from an environment, where only the proposed Socket API is available, [`pg-cloudflare`](https://github.com/brianc/node-postgres/blob/master/packages/pg-cloudflare/README.md) provides such an interface.
 
 ## Installation
 


### PR DESCRIPTION
- Updates readme to link directly for the WinterCG proposal
- Links to `pg-cloudflare` for discoverability, since a common use case for people viewing this implementation will be to support environments where only `connect()` is available.

Effectively — there are two ways of taking an existing package and making it work across runtimes:

# Using the `connect()` API as the interface, and when in a Node.js environment, relying on `@arrowood.dev/socket` when in a Node.js environment (which can end up cleaner, but can be a more invasive change, depending on the codebase) # Keeping existing code as-is, and in an environment where only `connect()` is supported, using `pg-cloudflare` to provide an equivalent interface [example](https://github.com/sidorares/node-mysql2/pull/2289/files#diff-e56fabfb5e90fd8f6265cfbe84f3701a85261d884e198bf61de34958cee4864aR7-R13)

cc @jasnell @dom96 @Ethan-Arrowood